### PR TITLE
fix de-hover in member boxes

### DIFF
--- a/src/components/memberlayout.js
+++ b/src/components/memberlayout.js
@@ -18,8 +18,9 @@ const AboutBox = styled.div`
     position: relative;
     flex: 1;
     flex-basis: 200px;
+    transition: all 0.25s ease;
+    
     &:hover {
-        transition: all 0.25s ease;
         transform: translateY(-2px)
     } 
     i {


### PR DESCRIPTION
The transition was only applied to the :hover style.